### PR TITLE
revise iou to softmax(iou)

### DIFF
--- a/main_charades_RL.py
+++ b/main_charades_RL.py
@@ -268,7 +268,9 @@ def train(epoch):
             log_probs[step, :] = log_prob.squeeze(1)
             rewards[step, :] = reward
             locations[step, :] = location
-            Predict_IoUs[step, :] = tIoU
+            # Predict_IoUs[step, :] = tIoU
+            #use softmax to keep predict iou range in 0-1
+            Predict_IoUs[step, :] = torch.squeeze(F.softmax(tIoU,dim=0))
 
         total_rewards_epoch.append(rewards.sum())
 


### PR DESCRIPTION
I try to add a softmax operation to predict IoU.  In the paper, it doesn't do this operation, though, during the training process, I find after I fix the bug about
```
Predict_IoUs = torch.zeros(opt.num_steps, batch_size)
Predict_IoUs[step, :] = tIoU
iou_loss += torch.abs(Previous_IoUs[i,j] - Predict_IoUs[i,j])
```
The predict iou will always not in 0-1. That will make the network get a really really bad performance, even training a long time with the pre-trained model.
For IoU problem, if choose to use a softmax operation, that will be not so bad.

Actually, several weeks ago, when I fix the "predict iou" and "location" bug, the performance will be worse. It is a very strange thing and the author of the paper didn't reply to my email.